### PR TITLE
Added a healthcheck endpoint enabled tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lint": "eslint . --ext .ts",
     "test": "jest --coverage",
     "test:ci": "jest --ci --coverage --config=jest.config.ts",
-    "build": "rimraf ./dist && npm-run-all clean lint tsc copy-assets",
-    "dev:start": "npm-run-all build start",
+    "build": "rimraf ./dist && npm-run-all clean lint test tsc copy-assets",
+    "dev:start": "npm-run-all test build start",
     "dev": "nodemon --watch src -e ts,ejs --exec npm run dev:start",
     "start": "npm run build && node dist/server.js",
     "start:container": "node dist/server.js"

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,10 +3,12 @@ import path from 'path';
 import express, { Application, Request, Response } from 'express';
 
 import { apiRoute } from './route/api';
+import { healthcheck } from './route/healthcheck';
 
 const app: Application = express();
 
 app.use('/api', apiRoute);
+app.use('/healthcheck', healthcheck);
 app.use('/public', express.static(`${__dirname}/public`));
 app.use('/css', express.static(`${__dirname}/css`));
 app.use('/assets', express.static(`${__dirname}/assets`));

--- a/src/route/healthcheck.ts
+++ b/src/route/healthcheck.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+export const healthcheck = Router();
+
+healthcheck.get('/', (req, res) => {
+    res.json({
+        status: 'App is running',
+        notes: 'Expand endpoint to check for database connection and other services.'
+    });
+});

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -3,8 +3,23 @@ import request from 'supertest';
 import app from '../src/app';
 
 describe('Test app.ts', () => {
-    test('Catch-all route', async () => {
+    test('App Homepage has correct title', async () => {
         const res = await request(app).get('/');
-        expect(res.body).toEqual({ message: 'Express server is running' });
+        expect(res.status).toBe(200);
+    });
+
+    test('Inital API endpoint works', async () => {
+        const res = await request(app).get('/api');
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ message: 'API is available' });
+    });
+
+    test('Check inital healthcheck endpoint works', async () => {
+        const res = await request(app).get('/healthcheck');
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({
+            status: 'App is running',
+            notes: 'Expand endpoint to check for database connection and other services.'
+        });
     });
 });


### PR DESCRIPTION
Tests are now enabled as part of the build process.  Expanded the tests
to include the new API endpoint, the healthcheck endpoint as well as
making sure we get a 200 from `/`.